### PR TITLE
Leverage ms-python.python extension to resolve python interpreter path automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.2.0 - unreleased
+
+### Added
+
+* [#39](https://github.com/afri-bit/vsconan/pull/39) Support detection of python interpreter by ms-python.python extension
+
 ## 1.1.0 - 2024-07-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ The default configuration file can be seen as following. You can extend the list
 * `VSConan: Open Workspace Configuration (JSON)`  
   Open the workspace configuration file in the editor
 
-Further information of currrent supported features is available [here](doc/FEATURES.md).
+Further information of current supported features is available [here](doc/FEATURES.md).
 
 ## Release Notes
 Detailed release notes are available [here](CHANGELOG.md).

--- a/doc/FEATURES.md
+++ b/doc/FEATURES.md
@@ -62,6 +62,7 @@
   * export-pkg
 * Add editable package
 * Remove editable package
+* Automatic selection of Python interpreter using the ms-python.python extension
 
 ## General
 * Define multiple conan profiles inside `settings.json` that you can use for the extension.

--- a/package.json
+++ b/package.json
@@ -831,6 +831,7 @@
         "ts-jest": "29.1.2"
     },
     "dependencies": {
+        "@vscode/python-extension": "^1.0.5",
         "child_process": "^1.0.2"
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,7 @@ export function activate(context: vscode.ExtensionContext) {
     initContextState(context);
 
     // Create Configuration Manager object to store and get some configuration
-    let settingsPropertyManager = new SettingsPropertyManager(context);
+    let settingsPropertyManager = new SettingsPropertyManager(context, channelVSConan);
 
     let conanApiManager: ConanAPIManager = new ConanAPIManager();
 

--- a/src/extension/manager/vsconanWorkspace.ts
+++ b/src/extension/manager/vsconanWorkspace.ts
@@ -84,16 +84,16 @@ export class VSConanWorkspaceManager extends ExtensionManager {
 
     private updateStatusBar() {
         let selectedProfile: string | undefined = this.settingsPropertyManager.getSelectedConanProfile();
-        let selectedProfileObject: ConanProfileConfiguration | undefined = this.settingsPropertyManager.getConanProfileObject(selectedProfile!);
-
-        if (selectedProfileObject && selectedProfileObject.isValid()) {
-            this.statusBarConanVersion.text = `$(extensions) VSConan | conan${selectedProfileObject.conanVersion} - ${selectedProfile}`;
-            this.statusBarConanVersion.color = "";
-        }
-        else {
-            this.statusBarConanVersion.text = `$(extensions) VSConan | -`;
-            this.statusBarConanVersion.color = "#FF3333";
-        }
+        this.settingsPropertyManager.getConanProfileObject(selectedProfile!).then(selectedProfileObject => {
+            if (selectedProfileObject && selectedProfileObject.isValid()) {
+                this.statusBarConanVersion.text = `$(extensions) VSConan | conan${selectedProfileObject.conanVersion} - ${selectedProfile}`;
+                this.statusBarConanVersion.color = "";
+            }
+            else {
+                this.statusBarConanVersion.text = `$(extensions) VSConan | -`;
+                this.statusBarConanVersion.color = "#FF3333";
+            }
+        });
     }
 
     /**
@@ -108,30 +108,31 @@ export class VSConanWorkspaceManager extends ExtensionManager {
 
         let profileList: Array<string> = this.settingsPropertyManager.getListOfConanProfiles();
 
-        let quickPickItems = [];
+        (async () => {
+            let quickPickItems = [];
+            for (let i = 0; i < profileList.length; i++) {
+                let profileObject: ConanProfileConfiguration | undefined = await this.settingsPropertyManager.getConanProfileObject(profileList[i]);
 
-        for (let i = 0; i < profileList.length; i++) {
-
-            let profileObject: ConanProfileConfiguration | undefined = this.settingsPropertyManager.getConanProfileObject(profileList[i]);
-
-            quickPickItems.push({
-                label: profileList[i],
-                description: `Conan Version ${profileObject?.conanVersion}`,
-                detail: profileObject?.conanExecutionMode,
-                index: i,
-                conanVersion: profileObject?.conanVersion,
-            });
-        }
-
-        quickPickItems.map(label => ({ label }));
-        quickPick.items = quickPickItems;
-
-        const wsChoice = vscode.window.showQuickPick(quickPickItems);
-
-        wsChoice.then(result => {
-            if (result) {
-                this.settingsPropertyManager.updateConanProfile(result?.label);
+                quickPickItems.push({
+                    label: profileList[i],
+                    description: `Conan Version ${profileObject?.conanVersion}`,
+                    detail: profileObject?.conanExecutionMode,
+                    index: i,
+                    conanVersion: profileObject?.conanVersion,
+                });
             }
+            return quickPickItems;
+        })().then(quickPickItems => {
+            quickPickItems.map(label => ({ label }));
+            quickPick.items = quickPickItems;
+
+            const wsChoice = vscode.window.showQuickPick(quickPickItems);
+
+            wsChoice.then(result => {
+                if (result) {
+                    this.settingsPropertyManager.updateConanProfile(result?.label);
+                }
+            });
         });
     }
 
@@ -182,94 +183,91 @@ export class VSConanWorkspaceManager extends ExtensionManager {
      * Function to execute the selected Conan command
      * Since the flow of conan commands is similar, the flow of execution will be grouped within this function
      * Which command needs to be executed is determined using ENUM ConanCommand
-     * 
+     *
      * @param cmdType Enumeration type to determine which command to be executed
      */
-    private executeConanCommand(cmdType: ConanCommand): void {
+    private async executeConanCommand(cmdType: ConanCommand) {
         // The flow of following commands is the same by selecting the workspace first
         // Check the configuration and executed pre selected command based on this function argument
-        let ws = utils.workspace.selectWorkspace();
+        let wsPath = await utils.workspace.selectWorkspace();
 
-        ws.then(wsPath => {
+        let configPath = path.join(wsPath!, constants.VSCONAN_FOLDER, constants.CONFIG_FILE);
 
-            let configPath = path.join(wsPath!, constants.VSCONAN_FOLDER, constants.CONFIG_FILE);
+        if (fs.existsSync(configPath)) {
+            let configWorkspace = new ConfigWorkspace();
+            let configText = fs.readFileSync(configPath, 'utf8');
+            configWorkspace = JSON.parse(configText);
 
-            if (fs.existsSync(configPath)) {
-                let configWorkspace = new ConfigWorkspace();
-                let configText = fs.readFileSync(configPath, 'utf8');
-                configWorkspace = JSON.parse(configText);
+            let conanCommand = "";
+            let commandBuilder: CommandBuilder | undefined;
+            let conanVersion: string | null = "";
 
-                let conanCommand = "";
-                let commandBuilder: CommandBuilder | undefined;
-                let conanVersion: string | null = "";
+            // Get current profile
+            let currentConanProfile = this.settingsPropertyManager.getSelectedConanProfile();
 
-                // Get current profile
-                let currentConanProfile = this.settingsPropertyManager.getSelectedConanProfile();
+            if (currentConanProfile && await this.settingsPropertyManager.isProfileValid(currentConanProfile!)) {
+                conanVersion = await this.settingsPropertyManager.getConanVersionOfProfile(currentConanProfile!);
+                commandBuilder = CommandBuilderFactory.getCommandBuilder(conanVersion!);
 
-                if (currentConanProfile && this.settingsPropertyManager.isProfileValid(currentConanProfile!)) {
-                    conanVersion = this.settingsPropertyManager.getConanVersionOfProfile(currentConanProfile!);
-                    commandBuilder = CommandBuilderFactory.getCommandBuilder(conanVersion!);
+                let conanProfileObject: ConanProfileConfiguration | undefined = await this.settingsPropertyManager.getConanProfileObject(currentConanProfile!);
 
-                    let conanProfileObject: ConanProfileConfiguration | undefined = this.settingsPropertyManager.getConanProfileObject(currentConanProfile!);
-
-                    if (conanProfileObject?.conanExecutionMode === "pythonInterpreter" && conanProfileObject.conanPythonInterpreter) {
-                        conanCommand = `${conanProfileObject.conanPythonInterpreter} -m conans.conan`;
-                    }
-                    else if (conanProfileObject?.conanExecutionMode === "conanExecutable" && conanProfileObject.conanExecutable) {
-                        conanCommand = conanProfileObject.conanExecutable;
-                    }
-                    else {
-                        vscode.window.showErrorMessage("Empty Conan Command");
-                        return;
-                    }
+                if (conanProfileObject?.conanExecutionMode === "pythonInterpreter" && conanProfileObject.conanPythonInterpreter) {
+                    conanCommand = `${conanProfileObject.conanPythonInterpreter} -m conans.conan`;
+                }
+                else if (conanProfileObject?.conanExecutionMode === "conanExecutable" && conanProfileObject.conanExecutable) {
+                    conanCommand = `${conanProfileObject.conanExecutable}`;
                 }
                 else {
-                    vscode.window.showErrorMessage("");
+                    vscode.window.showErrorMessage("Empty Conan Command");
                     return;
-                }
-
-                switch (+cmdType) {
-                    case ConanCommand.create: {
-                        this.executeCommandConanCreate(wsPath!, conanCommand, commandBuilder!, configWorkspace.commandContainer.create);
-                        break;
-                    }
-                    case ConanCommand.install: {
-                        this.executeCommandConanInstall(wsPath!, conanCommand, commandBuilder!, configWorkspace.commandContainer.install);
-                        break;
-                    }
-                    case ConanCommand.build: {
-                        this.executeCommandConanBuild(wsPath!, conanCommand, commandBuilder!, configWorkspace.commandContainer.build);
-                        break;
-                    }
-                    case ConanCommand.source: {
-                        this.executeCommandConanSource(wsPath!, conanCommand, commandBuilder!, configWorkspace.commandContainer.source);
-                        break;
-                    }
-                    case ConanCommand.package: {
-                        if (conanVersion === "2") {
-                            vscode.window.showErrorMessage("This command doesn't work on Conan 2");
-                            break;
-                        }
-
-                        this.executeCommandConanPackage(wsPath!, conanCommand, commandBuilder!, configWorkspace.commandContainer.pkg);
-                        break;
-                    }
-                    case ConanCommand.packageExport: {
-                        this.executeCommandConanPackageExport(wsPath!, conanCommand, commandBuilder!, configWorkspace.commandContainer.pkgExport);
-                        break;
-                    }
                 }
             }
             else {
-                vscode.window.showWarningMessage(`Unable to find configuration file in the workspace '${wsPath}'`);
+                vscode.window.showErrorMessage("");
+                return;
             }
-        });
+
+            switch (+cmdType) {
+                case ConanCommand.create: {
+                    this.executeCommandConanCreate(wsPath!, conanCommand, commandBuilder!, configWorkspace.commandContainer.create);
+                    break;
+                }
+                case ConanCommand.install: {
+                    this.executeCommandConanInstall(wsPath!, conanCommand, commandBuilder!, configWorkspace.commandContainer.install);
+                    break;
+                }
+                case ConanCommand.build: {
+                    this.executeCommandConanBuild(wsPath!, conanCommand, commandBuilder!, configWorkspace.commandContainer.build);
+                    break;
+                }
+                case ConanCommand.source: {
+                    this.executeCommandConanSource(wsPath!, conanCommand, commandBuilder!, configWorkspace.commandContainer.source);
+                    break;
+                }
+                case ConanCommand.package: {
+                    if (conanVersion === "2") {
+                        vscode.window.showErrorMessage("This command doesn't work on Conan 2");
+                        break;
+                    }
+
+                    this.executeCommandConanPackage(wsPath!, conanCommand, commandBuilder!, configWorkspace.commandContainer.pkg);
+                    break;
+                }
+                case ConanCommand.packageExport: {
+                    this.executeCommandConanPackageExport(wsPath!, conanCommand, commandBuilder!, configWorkspace.commandContainer.pkgExport);
+                    break;
+                }
+            }
+        }
+        else {
+            vscode.window.showWarningMessage(`Unable to find configuration file in the workspace '${wsPath}'`);
+        }
     }
 
     /**
      * Helper method to get the index of selected command.
      * This method basically will pop up quick pick window to select configuration where the user has to choose.
-     * @param configList List of configuration 
+     * @param configList List of configuration
      * @returns Index of selected configuration | undefined on error or no selection
      */
     private getCommandConfigIndex(configList: Array<ConfigCommand>): Promise<number | undefined> {

--- a/src/extension/manager/vsconanWorkspace.ts
+++ b/src/extension/manager/vsconanWorkspace.ts
@@ -88,6 +88,7 @@ export class VSConanWorkspaceManager extends ExtensionManager {
             if (selectedProfileObject && selectedProfileObject.isValid()) {
                 this.statusBarConanVersion.text = `$(extensions) VSConan | conan${selectedProfileObject.conanVersion} - ${selectedProfile}`;
                 this.statusBarConanVersion.color = "";
+                this.statusBarConanVersion.tooltip = new vscode.MarkdownString(`### Python Interpreter\n\`${selectedProfileObject.conanPythonInterpreter}\`\n### Conan Executable\n\`${selectedProfileObject.conanExecutable}\``);
             }
             else {
                 this.statusBarConanVersion.text = `$(extensions) VSConan | -`;

--- a/src/extension/settings/settingsManager.ts
+++ b/src/extension/settings/settingsManager.ts
@@ -63,12 +63,12 @@ export class SettingsManager {
         }
     }
 
-    private changeConanProfile() {
+    private async changeConanProfile() {
         let selectedProfile: string | undefined = vscode.workspace.getConfiguration("vsconan.conan.profile").get("default");
 
         if (this.settingsPropertyManager.isProfileAvailable(selectedProfile!) &&
-            this.settingsPropertyManager.isProfileValid(selectedProfile!)) {
-            let profileObject = this.settingsPropertyManager.getConanProfileObject(selectedProfile!);
+            await this.settingsPropertyManager.isProfileValid(selectedProfile!)) {
+            let profileObject = await this.settingsPropertyManager.getConanProfileObject(selectedProfile!);
 
             let conanExecutionMode: ConanExecutionMode = ConanExecutionMode.conan;
 

--- a/src/extension/settings/settingsPropertyManager.ts
+++ b/src/extension/settings/settingsPropertyManager.ts
@@ -112,17 +112,20 @@ export class SettingsPropertyManager {
             profileObject.escapeWhitespace();
         }
 
-        let pythonInterpreter = await python.getCurrentPythonInterpreter();
-        if (pythonInterpreter !== undefined) {
-            this.outputChannel?.append(`Using Python interpreter: ${pythonInterpreter}\n`);
-            if (!profileObject?.conanPythonInterpreter) {
-                profileObject!.conanPythonInterpreter = pythonInterpreter;
-            }
-            if (!profileObject?.conanExecutable) {
-                const conanExecutable = path.join(path.dirname(pythonInterpreter), "conan");
-                if (existsSync(conanExecutable)) {
-                    profileObject!.conanExecutable = conanExecutable;
+        if (profileObject) {
+            let pythonInterpreter = await python.getCurrentPythonInterpreter();
+            if (pythonInterpreter !== undefined) {
+                if (!profileObject.conanPythonInterpreter) {
+                    profileObject.conanPythonInterpreter = pythonInterpreter;
                 }
+                if (!profileObject.conanExecutable) {
+                    const conanExecutable = path.join(path.dirname(pythonInterpreter), "conan" + (process.platform === "win32" ? ".exe" : ""));
+                    if (existsSync(conanExecutable)) {
+                        profileObject.conanExecutable = conanExecutable;
+                    }
+                }
+                this.outputChannel?.append(`Using Python interpreter: ${profileObject.conanPythonInterpreter}\n`);
+                this.outputChannel?.append(`Using Conan executable: ${profileObject.conanExecutable}\n`);
             }
         }
 

--- a/src/extension/settings/settingsPropertyManager.ts
+++ b/src/extension/settings/settingsPropertyManager.ts
@@ -1,8 +1,8 @@
 import * as vscode from "vscode";
 
 import { ConanProfileConfiguration } from "./model";
-import { general } from "../../utils/utils";
-
+import { general, python } from "../../utils/utils";
+import path = require("path");
 
 /**
  * Class to manage the extension configuration
@@ -94,7 +94,7 @@ export class SettingsPropertyManager {
         return listOfConanProfile;
     }
 
-    public getConanProfileObject(profileName: string): ConanProfileConfiguration | undefined {
+    public async getConanProfileObject(profileName: string): Promise<ConanProfileConfiguration | undefined> {
 
         let profileObject: ConanProfileConfiguration | undefined = undefined;
 
@@ -109,6 +109,17 @@ export class SettingsPropertyManager {
             profileObject.escapeWhitespace();
         }
 
+        let pythonInterpreter = await python.getCurrentPythonInterpreter();
+        if (pythonInterpreter !== undefined) {
+            if (!profileObject?.conanPythonInterpreter) {
+                profileObject!.conanPythonInterpreter = pythonInterpreter;
+            }
+            if (!profileObject?.conanExecutable) {
+                profileObject!.conanExecutable = path.join(path.dirname(pythonInterpreter), "conan");
+            }
+        }
+
+        console.log(profileObject);
         return profileObject;
     }
 
@@ -116,10 +127,10 @@ export class SettingsPropertyManager {
         return vscode.workspace.getConfiguration("vsconan.conan.profile").get("default");
     }
 
-    public isProfileValid(profileName: string): boolean {
+    public async isProfileValid(profileName: string): Promise<boolean> {
         let valid: boolean = false;
 
-        let profileObject: ConanProfileConfiguration | undefined = this.getConanProfileObject(profileName);
+        let profileObject: ConanProfileConfiguration | undefined = await this.getConanProfileObject(profileName);
 
         if ((profileObject) && (profileObject.isValid())) {
             valid = true;
@@ -128,11 +139,11 @@ export class SettingsPropertyManager {
         return valid;
     }
 
-    public getConanVersionOfProfile(profileName: string): string | null {
+    public async getConanVersionOfProfile(profileName: string): Promise<string | null> {
 
         let conanVersion: string | null = null;
 
-        let profileObject: ConanProfileConfiguration | undefined = this.getConanProfileObject(profileName);
+        let profileObject: ConanProfileConfiguration | undefined = await this.getConanProfileObject(profileName);
 
         if ((profileObject) && (profileObject.isValid())) {
             conanVersion = profileObject.conanVersion;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -4,6 +4,7 @@ import * as os from "os";
 import * as constants from "./constants";
 import * as fs from "fs";
 import { ConfigWorkspace } from "../conans/workspace/configWorkspace";
+import { PythonExtension, ResolvedEnvironment } from '@vscode/python-extension';
 import {
     CommandContainer, ConfigCommandBuild, ConfigCommandCreate,
     ConfigCommandInstall, ConfigCommandPackage, ConfigCommandPackageExport,
@@ -220,5 +221,27 @@ export namespace general {
         }
 
         return instance;
+    }
+}
+
+export namespace python {
+    let _api: PythonExtension | undefined;
+
+    async function getPythonExtensionAPI(): Promise<PythonExtension | undefined> {
+        if (_api) {
+            return _api;
+        }
+        _api = await PythonExtension.api();
+        return _api;
+    }
+
+    export async function getCurrentPythonInterpreter(): Promise<string | undefined> {
+        let pythonExtension = vscode.extensions.getExtension("ms-python.python");
+        if (!pythonExtension) {
+            return;
+        }
+        const api = await getPythonExtensionAPI();
+        const environment = await api?.environments.resolveEnvironment(api?.environments.getActiveEnvironmentPath());
+        return environment?.executable.uri?.fsPath;
     }
 }


### PR DESCRIPTION
If the `ms-python.python` extension is installed (which is true for most developers, I guess) VSConan can automatically resolve the Python interpreter path and Conan executable using the currently activated Python Environment.